### PR TITLE
fix #134: app&web case should be failed not error

### DIFF
--- a/haf/apphelper.py
+++ b/haf/apphelper.py
@@ -81,7 +81,7 @@ class Stage(object):
         self.show_try = True
         self.time_sleep = 5
         self.info = {}
-        self.result = "PASS"
+        self.result = "NOT RUN"
         self.run_count = 0
     
     def constructor(self, input: dict={}):

--- a/haf/runner.py
+++ b/haf/runner.py
@@ -439,17 +439,18 @@ class AppRunner(BaseRunner):
                 logger.info(f"{self.key} : {key} == {case.stages.get(key).deserialize()}", __name__)
                 png_dir = f"{self.log_dir}"
                 png_name = f"{case.bench_name}.{case.ids.id}.{case.ids.subid}.{case.ids.name}.{key}"
+                case.pngs[key] = {"before": f"./png/{png_name}-before.png", "after": f"./png/{png_name}-after.png"}
                 png_before = save_screen_shot(driver, png_dir, f"{png_name}-before")
                 self.run_stage(case, page, case.stages.get(key, Stage()), result)
                 png_after = save_screen_shot(driver, png_dir, f"{png_name}-after")
-                case.pngs[key] = {"before": f"./png/{png_name}-before.png", "after": f"./png/{png_name}-after.png"}
             result.case = case
             result.result = RESULT_PASS
             result.run_error = None
         except Exception as e:
             logger.error(f"{self.key} : {e}", __name__)
             result.run_error = e
-            result.result = RESULT_ERROR
+            # TODO : make the result to error and fail
+            result.result = RESULT_FAIL # RESULT_ERROR, fix #134
         result.on_case_end()
         return result
 
@@ -573,17 +574,18 @@ class WebRunner(BaseRunner):
                 logger.info(f"{self.key} : {key} == {case.stages.get(key).deserialize()}", __name__)
                 png_dir = f"{self.log_dir}"
                 png_name = f"{case.bench_name}.{case.ids.id}.{case.ids.subid}.{case.ids.name}.{key}"
+                case.pngs[key] = {"before": f"./png/{png_name}-before.png", "after": f"./png/{png_name}-after.png"}
                 png_before = web_save_screen_shot(driver, png_dir, f"{png_name}-before")
                 self.run_stage(case, page, case.stages.get(key, WebStage()), result)
                 png_after = web_save_screen_shot(driver, png_dir, f"{png_name}-after")
-                case.pngs[key] = {"before": f"./png/{png_name}-before.png", "after": f"./png/{png_name}-after.png"}
             result.case = case
             result.result = RESULT_PASS
             result.run_error = None
         except Exception as e:
             logger.error(f"{self.key} : {e}", __name__)
             result.run_error = e
-            result.result = RESULT_ERROR
+            # TODO : make the result to error and fail
+            result.result = RESULT_FAIL # RESULT_ERROR, fix #134
         result.on_case_end()
         return result
 

--- a/haf/webhelper.py
+++ b/haf/webhelper.py
@@ -81,7 +81,7 @@ class WebStage(object):
         self.show_try = True
         self.time_sleep = 5
         self.info = {}
-        self.result = "PASS"
+        self.result = "NOT RUN"
         self.run_count = 1
     
     def constructor(self, input: dict={}):


### PR DESCRIPTION
- fix #134 , also fix web cases same issue
```python
     except Exception as e:
            logger.error(f"{self.key} : {e}", __name__)
            result.run_error = e
            # TODO : make the result to error and fail
            result.result = RESULT_FAIL # RESULT_ERROR, fix #134
```
- fix no screenshot when stage failed, move this before run stage
```python
    case.pngs[key] = {"before": f"./png/{png_name}-before.png", "after": f"./png/{png_name}-after.png"}
```